### PR TITLE
fix: Smooth border-radius hover animations on App Icon and Button

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -74,7 +74,7 @@ function App() {
         <img
           src="/favicon.svg"
           alt="Simple Launcher - Minimalist Launcher App Icon"
-          className="w-24 h-24 mb-12 shadow-lg rounded-3xl bg-white p-2 animate-fade-in-up animate-delay-100 transition-all duration-300 hover:rounded-full"
+          className="w-24 h-24 mb-12 shadow-lg rounded-3xl bg-white p-2 animate-fade-in-up animate-delay-100 transition-all duration-300 ease-in-out hover:rounded-[48px]"
         />
 
         {/* Main Heading */}
@@ -96,7 +96,7 @@ function App() {
           href="https://play.google.com/store/apps/details?id=com.dino.simple&pcampaignid=web_share"
           target="_blank"
           rel="noopener noreferrer"
-          className="inline-flex items-center bg-transparent border-2 border-gray-700 hover:border-white rounded-2xl px-6 py-3 transition-all duration-300 hover:bg-white hover:text-black group animate-fade-in-up animate-delay-400 hover:rounded-full hover:scale-105"
+          className="inline-flex items-center bg-transparent border-2 border-gray-700 hover:border-white rounded-2xl px-6 py-3 transition-all duration-300 ease-in-out hover:bg-white hover:text-black group animate-fade-in-up animate-delay-400 hover:rounded-[32px] hover:scale-105"
         >
           <svg className="w-8 h-8 mr-3" viewBox="0 0 24 24" fill="currentColor">
             <path d="M3,20.5V3.5C3,2.91 3.34,2.39 3.84,2.15L13.69,12L3.84,21.85C3.34,21.61 3,21.09 3,20.5M16.81,15.12L6.05,21.34L14.54,12.85L16.81,15.12M20.16,10.81C20.5,11.08 20.75,11.5 20.75,12C20.75,12.5 20.53,12.92 20.18,13.18L17.89,14.5L15.39,12L17.89,9.5L20.16,10.81M6.05,2.66L16.81,8.88L14.54,11.15L6.05,2.66Z"/>


### PR DESCRIPTION
- Replace `hover:rounded-full` with `hover:rounded-[48px]` for the App Icon to match its width/height dimensions.
- Replace `hover:rounded-full` with `hover:rounded-[32px]` for the Google Play Button to reach pill shape smoothly.
- Add `ease-in-out` timing to both elements.

---
*PR created automatically by Jules for task [6334636324285396100](https://jules.google.com/task/6334636324285396100) started by @dinoy-raj*